### PR TITLE
added maven-chrome/jdk-8 image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/custom-images/maven-chrome/j8k-8/Dockerfile
+++ b/custom-images/maven-chrome/j8k-8/Dockerfile
@@ -1,0 +1,13 @@
+FROM harnesscommunity/ci-base-image
+
+RUN apt-get update
+
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && sed -i 's|HERE/chrome"|HERE/chrome" --disable-setuid-sandbox --no-sandbox|g' \
+           "/opt/google/chrome/google-chrome"
+
+RUN google-chrome --version           


### PR DESCRIPTION
added maven-chrome/jdk-8 custom image to harnesscommunity at [harnesscommunity/maven-chrome:jdk-8](https://hub.docker.com/layers/harnesscommunity/maven-chrome/jdk-8/images/sha256-464e938829966209a906b7d029defb883f04ab0bed9c53391fbaccd0008a8412?context=repo)

fixes #14 
